### PR TITLE
skip human-readable lines when reading redis info

### DIFF
--- a/redis/userparameter_redis.conf
+++ b/redis/userparameter_redis.conf
@@ -8,6 +8,6 @@
 # Discovery
 
 # Return Redis statistics
-UserParameter=redis.local[*],redis-cli -h 127.0.0.1 -p 6379 info|grep $1|cut -d : -f2
-UserParameter=redis.status[*],redis-cli -h $1 -p $2 info|grep $3|cut -d : -f2
+UserParameter=redis.local[*],redis-cli -h 127.0.0.1 -p 6379 info|grep $1|grep -v _human|cut -d : -f2
+UserParameter=redis.status[*],redis-cli -h $1 -p $2 info|grep $3|grep -v _human|cut -d : -f2
 UserParameter=redis.proc,pidof redis-server | wc -l


### PR DESCRIPTION
While using redis v3.0.6, there was data for `used_memory_rss` item in Redis Used Memory graph.
After upgradig to redis v3.2.8, we started to have empty data for `used_memory_rss`.

Quick analysis of the problem revealed the following case:

In redis v3.0.6:

    $ redis-cli info | grep used_memory_rss
    used_memory_rss:71753728

In redis v3.2.8:

    $redis-cli info | grep used_memory_rss
    used_memory_rss:17555456
    used_memory_rss_human:16.74M

So the newer version now includes an extra line in human friendly format. This breaks user parameters expecting numeric values. To resolve this issue, I added extra `grep` to exclude those lines in human friendly format and everything works as before.
