### PR TITLE
to fix issue #29

### DIFF
--- a/mongodb/mongodb.sh
+++ b/mongodb/mongodb.sh
@@ -57,7 +57,7 @@ if [ $mongo_status -ne $EXIT_OK ] ; then
   echo "mongo exec error"
   exit $EXIT_ERROR
 fi
-value=$(echo $output | jq $index)
+value=$(echo $output | jq $index 2>/dev/null)
 jq_status=$?
 echo $value
 


### PR DESCRIPTION
mongo command by default will try to access ~/.dbshell to write history of commands.
since mongo command does not have any flag to disable history logging, we can add add 2>/dev/null to jq to ignore error while trying to write in .dbshell history file and echo correct output to zabbix server.